### PR TITLE
Variables written into frame are of the proper type int now.

### DIFF
--- a/golang/src/main/java/com/oracle/app/nodes/expression/GoAddNode.java
+++ b/golang/src/main/java/com/oracle/app/nodes/expression/GoAddNode.java
@@ -4,6 +4,7 @@ import java.math.BigInteger;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.ImplicitCast;
 import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInfo;
 import com.oracle.app.nodes.GoBinaryNode;
 import com.oracle.app.nodes.GoTypes;
@@ -43,4 +44,12 @@ public abstract class GoAddNode extends GoBinaryNode {
     protected boolean isString(Object a, Object b) {
         return a instanceof String || b instanceof String;
     }
+
+
+	@Override
+	public String toString() {
+		return "Add Node";
+	}
+
+    
 }

--- a/golang/src/main/java/com/oracle/app/nodes/local/GoReadLocalVariableNode.java
+++ b/golang/src/main/java/com/oracle/app/nodes/local/GoReadLocalVariableNode.java
@@ -27,6 +27,11 @@ public abstract class GoReadLocalVariableNode extends GoExpressionNode {
      * created by the Truffle DSL based on the {@link NodeField} annotation on the class.
      */
     protected abstract FrameSlot getSlot();
+    
+    @Specialization(guards = "isInt(frame)")
+    protected int readInt(VirtualFrame frame){
+    	return FrameUtil.getIntSafe(frame, getSlot());
+    }
 
     @Specialization(guards = "isLong(frame)")
     protected long readLong(VirtualFrame frame) {
@@ -43,7 +48,7 @@ public abstract class GoReadLocalVariableNode extends GoExpressionNode {
         return FrameUtil.getBooleanSafe(frame, getSlot());
     }
 
-    @Specialization(replaces = {"readLong", "readBoolean"})
+    @Specialization(replaces = {"readInt", "readLong", "readBoolean"})
     protected Object readObject(VirtualFrame frame) {
         if (!frame.isObject(getSlot())) {
             /*
@@ -70,6 +75,10 @@ public abstract class GoReadLocalVariableNode extends GoExpressionNode {
      *            Guards without parameters are assumed to be pure, but our guard depends on the
      *            slot kind which can change.
      */
+    
+    protected boolean isInt(VirtualFrame frame){
+    	return getSlot().getKind() == FrameSlotKind.Int;
+    }
     protected boolean isLong(VirtualFrame frame) {
         return getSlot().getKind() == FrameSlotKind.Long;
     }

--- a/golang/src/main/java/com/oracle/app/nodes/local/GoWriteLocalVariableNode.java
+++ b/golang/src/main/java/com/oracle/app/nodes/local/GoWriteLocalVariableNode.java
@@ -23,6 +23,17 @@ public abstract class GoWriteLocalVariableNode  extends GoExpressionNode{
 	     * created by the Truffle DSL based on the {@link NodeField} annotation on the class.
 	     */
 	    protected abstract FrameSlot getSlot();
+	    
+	    
+	    
+	    @Specialization(guards = "isIntOrIllegal(frame)")
+	    protected int writeInt(VirtualFrame frame, int value) {
+	        /* Initialize type on first write of the local variable. No-op if kind is already Long. */
+	        getSlot().setKind(FrameSlotKind.Int);
+
+	        frame.setInt(getSlot(), value);
+	        return value;
+	    }
 
 	    /**
 	     * Specialized method to write a primitive {@code long} value. This is only possible if the
@@ -57,7 +68,7 @@ public abstract class GoWriteLocalVariableNode  extends GoExpressionNode{
 	     * {@link Object}, it is guaranteed to never fail, i.e., once we are in this specialization the
 	     * node will never be re-specialized.
 	     */
-	    @Specialization(replaces = {"writeLong", "writeBoolean"})
+	    @Specialization(replaces = {"writeInt", "writeLong", "writeBoolean"})
 	    protected Object write(VirtualFrame frame, Object value) {
 	        /*
 	         * Regardless of the type before, the new and final type of the local variable is Object.
@@ -80,6 +91,10 @@ public abstract class GoWriteLocalVariableNode  extends GoExpressionNode{
 	     *            Guards without parameters are assumed to be pure, but our guard depends on the
 	     *            slot kind which can change.
 	     */
+	    
+	    protected boolean isIntOrIllegal(VirtualFrame frame) {
+	        return getSlot().getKind() == FrameSlotKind.Int || getSlot().getKind() == FrameSlotKind.Illegal;
+	    }
 	    protected boolean isLongOrIllegal(VirtualFrame frame) {
 	        return getSlot().getKind() == FrameSlotKind.Long || getSlot().getKind() == FrameSlotKind.Illegal;
 	    }

--- a/golang/src/main/java/com/oracle/app/nodes/types/GoIntNode.java
+++ b/golang/src/main/java/com/oracle/app/nodes/types/GoIntNode.java
@@ -12,7 +12,7 @@ public class GoIntNode extends GoExpressionNode {
 
     @Override
     public int executeInteger(VirtualFrame virtualFrame) {
-        return this.number;
+        return number;
     }
 
     @Override
@@ -22,6 +22,6 @@ public class GoIntNode extends GoExpressionNode {
 
 	@Override
 	public Object executeGeneric(VirtualFrame frame) {
-		return this.number;
+		return number;
 	}
 }

--- a/golang/src/main/java/com/oracle/app/parser/Parser.java
+++ b/golang/src/main/java/com/oracle/app/parser/Parser.java
@@ -88,8 +88,8 @@ public class Parser {
 		}
 		//dumpTree(k,0);
 		
-		GoVisitor visitor = new GoVisitor();
-		k.accept(visitor);
+		//GoVisitor visitor = new GoVisitor();
+		//k.accept(visitor);
 		
 		GoTruffle truffleVisitor = new GoTruffle(language, source);
 		k.accept(truffleVisitor);

--- a/golang/src/main/java/com/oracle/app/parser/ir/GoTruffle.java
+++ b/golang/src/main/java/com/oracle/app/parser/ir/GoTruffle.java
@@ -91,6 +91,8 @@ public class GoTruffle implements GoIRVisitor {
 		this.language = language;
 		this.source = source;
         this.allFunctions = new HashMap<>();
+        //Creates a block to cover for idents located outside of a function body
+        startBlock();
     }
 
     public Map<String, GoRootNode> getAllFunctions() {
@@ -134,17 +136,16 @@ public class GoTruffle implements GoIRVisitor {
 		String name = node.getIdent();
 		GoExpressionNode result = null;
 		//Cannot check for if writing value yet
-		if(node.parent instanceof GoIRArrayListExprNode) {
-	        
-	        final FrameSlot frameSlot = lexicalscope.locals.get(name);
-	        if (frameSlot != null) {
+	    final FrameSlot frameSlot = lexicalscope.locals.get(name);
+	    if (frameSlot != null) {
 	            /* Read of a local variable. */
-	        	return (GoExpressionNode)GoReadLocalVariableNodeGen.create(frameSlot);
-	        } /*else {
+	    	return (GoExpressionNode)GoReadLocalVariableNodeGen.create(frameSlot);
+	    } 
+	    	/*else {
 	             Read of a global name. In our language, the only global names are functions. 
 	        	return (GoExpressionNode)new GoFunctionLiteralNode(language, name);
 	        }*/
-		}else {
+		else {
 			result = null;
 			if(node.getChild() != null)
 				result = (GoExpressionNode) node.getChild().accept(this);


### PR DESCRIPTION
Int types are properly written into the frames now and can be read. Any other type added follows the same format and needs to be filled in for WriteNode and ReadNode. All the other types need to be filled in.